### PR TITLE
Add stats slash command

### DIFF
--- a/src/main/java/etc/soap/paperDiscord/DiscordCommandListener.java
+++ b/src/main/java/etc/soap/paperDiscord/DiscordCommandListener.java
@@ -82,6 +82,8 @@ public class DiscordCommandListener extends ListenerAdapter {
                                 .addOption(OptionType.USER, "user", "The Discord user whose perk should be reset."),
                         Commands.slash("serverstatus", "Check the status of a Minecraft server")
                                 .addOption(OptionType.STRING, "server_ip", "The IP of the server you want to check", false),
+                        Commands.slash("stats", "Show a player's statistics")
+                                .addOption(OptionType.STRING, "player", "The Minecraft player to look up", true),
                         Commands.slash("banformat", "Start the ban appeal process")
                                 .addOption(OptionType.USER, "user", "The Discord user to invite to fill out the ban appeal form"),
                         Commands.slash("serverstatusembed", "Send a server status embed that updates every 30 seconds")
@@ -121,6 +123,9 @@ public class DiscordCommandListener extends ListenerAdapter {
                 break;
             case "banformat":
                 handleBanFormatCommand(event);
+                break;
+            case "stats":
+                handleStatsCommand(event);
                 break;
             default:
                 event.reply("Unknown command").setEphemeral(true).queue();

--- a/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
+++ b/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
@@ -18,16 +18,15 @@ public class PaperDiscord extends JavaPlugin {
     // We'll store references to our auto-posted messages so we can delete them on shutdown
     private Message embedMessage;
     private Message lastUpdatedMessage;
+    private DatabaseManager dbManager;
 
     @Override
     public void onEnable() {
+        // Ensure config exists before reading values
+        saveDefaultConfig();
 
         dbManager = new DatabaseManager(this);
-        discordCommandListener = new DiscordCommandListener(this, db);
-        discordCommandListener.startBot();
-
-        saveDefaultConfig();
-        discordCommandListener = new DiscordCommandListener(this);
+        discordCommandListener = new DiscordCommandListener(this, dbManager);
         discordCommandListener.startBot();
 
         // Delay to allow JDA to initialize before starting updaters
@@ -57,7 +56,7 @@ public class PaperDiscord extends JavaPlugin {
         Guild guild = jda.getGuildById(guildId);
         if (guild != null) {
             guild.retrieveCommands().queue(existingCommands -> {
-                List<String> commandsToKeep = List.of("boostperks", "reload", "balancedperks", "steadyperks", "resetperk", "serverstatus", "serverstatusembed", "banformat");
+                List<String> commandsToKeep = List.of("boostperks", "reload", "balancedperks", "steadyperks", "resetperk", "serverstatus", "stats", "serverstatusembed", "banformat");
                 for (net.dv8tion.jda.api.interactions.commands.Command command : existingCommands) {
                     if (!commandsToKeep.contains(command.getName())) {
                         guild.deleteCommandById(command.getId()).queue();


### PR DESCRIPTION
## Summary
- register `/stats` Discord command to look up a player's Minecraft stats
- keep the new command during guild command cleanup

## Testing
- `mvn -q test` *(Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b557f026cc832f8cb667170560bd8f