### PR TITLE
Add stats slash command

### DIFF
--- a/src/main/java/etc/soap/paperDiscord/DiscordCommandListener.java
+++ b/src/main/java/etc/soap/paperDiscord/DiscordCommandListener.java
@@ -4,24 +4,21 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
-import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
-import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
-import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
-import net.dv8tion.jda.api.interactions.modals.Modal;
-import net.dv8tion.jda.api.interactions.components.text.TextInput;
-import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import net.dv8tion.jda.api.interactions.modals.Modal;
-import net.dv8tion.jda.api.interactions.modals.ModalMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.text.TextInput;
+import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.interactions.modals.ModalMapping;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -30,8 +27,8 @@ import java.awt.*;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -82,6 +79,8 @@ public class DiscordCommandListener extends ListenerAdapter {
                                 .addOption(OptionType.USER, "user", "The Discord user whose perk should be reset."),
                         Commands.slash("serverstatus", "Check the status of a Minecraft server")
                                 .addOption(OptionType.STRING, "server_ip", "The IP of the server you want to check", false),
+                        Commands.slash("stats", "Show a player's statistics")
+                                .addOption(OptionType.STRING, "player", "The Minecraft player to look up", true),
                         Commands.slash("banformat", "Start the ban appeal process")
                                 .addOption(OptionType.USER, "user", "The Discord user to invite to fill out the ban appeal form"),
                         Commands.slash("serverstatusembed", "Send a server status embed that updates every 30 seconds")
@@ -121,6 +120,9 @@ public class DiscordCommandListener extends ListenerAdapter {
                 break;
             case "banformat":
                 handleBanFormatCommand(event);
+                break;
+            case "stats":
+                handleStatsCommand(event);
                 break;
             default:
                 event.reply("Unknown command").setEphemeral(true).queue();


### PR DESCRIPTION
## Summary
- register `/stats` Discord command to look up a player's Minecraft stats
- keep the new command during guild command cleanup
- fix JDA lifecycle by assigning the instance on startup and waiting for a full shutdown

## Testing
- `mvn -q test` *(Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b557f026cc832f8cb667170560bd8f