### PR TITLE
Fetch stats using player UUID

### DIFF
--- a/src/main/java/etc/soap/paperDiscord/DatabaseManager.java
+++ b/src/main/java/etc/soap/paperDiscord/DatabaseManager.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+
 public class DatabaseManager {
     private final HikariDataSource ds;
 
@@ -60,6 +61,27 @@ public class DatabaseManager {
         return Optional.empty();
     }
 
+    public Optional<PlayerInfo> getPlayerInfoByUUID(java.util.UUID uuid) {
+        String sql = "SELECT uuid, name, rank, first_join, playtime FROM player WHERE uuid = ? LIMIT 1";
+        try (Connection c = ds.getConnection(); PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, uuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(new PlayerInfo(
+                            rs.getString("uuid"),
+                            rs.getString("name"),
+                            rs.getString("rank"),
+                            rs.getLong("first_join"),
+                            rs.getInt("playtime")
+                    ));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return Optional.empty();
+    }
+
     // Aggregated duels totals
     public Optional<DuelsAggregated> getDuelsAggregatedByName(String name) {
         String sql = "SELECT COALESCE(SUM(kills),0) AS total_kills, COALESCE(SUM(deaths),0) AS total_deaths, " +
@@ -67,6 +89,29 @@ public class DatabaseManager {
                 "FROM duels_kit_stats WHERE name = ?";
         try (Connection c = ds.getConnection(); PreparedStatement ps = c.prepareStatement(sql)) {
             ps.setString(1, name);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(new DuelsAggregated(
+                            rs.getInt("total_kills"),
+                            rs.getInt("total_deaths"),
+                            rs.getInt("total_wins"),
+                            rs.getInt("total_losses"),
+                            rs.getInt("best_streak")
+                    ));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return Optional.empty();
+    }
+
+    public Optional<DuelsAggregated> getDuelsAggregatedByUUID(java.util.UUID uuid) {
+        String sql = "SELECT COALESCE(SUM(kills),0) AS total_kills, COALESCE(SUM(deaths),0) AS total_deaths, " +
+                "COALESCE(SUM(wins),0) AS total_wins, COALESCE(SUM(losses),0) AS total_losses, COALESCE(MAX(best_streak),0) AS best_streak " +
+                "FROM duels_kit_stats WHERE uuid = ?";
+        try (Connection c = ds.getConnection(); PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, uuid.toString());
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
                     return Optional.of(new DuelsAggregated(
@@ -108,6 +153,155 @@ public class DatabaseManager {
             e.printStackTrace();
         }
         return list;
+    }
+
+    public List<DuelsKitStats> getDuelsPerKitByUUID(java.util.UUID uuid, int limit) {
+        String sql = "SELECT kit, kills, deaths, wins, losses, streak, best_streak FROM duels_kit_stats WHERE uuid = ? ORDER BY kills DESC LIMIT ?";
+        List<DuelsKitStats> list = new ArrayList<>();
+        try (Connection c = ds.getConnection(); PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, uuid.toString());
+            ps.setInt(2, limit);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(new DuelsKitStats(
+                            rs.getString("kit"),
+                            rs.getInt("kills"),
+                            rs.getInt("deaths"),
+                            rs.getInt("wins"),
+                            rs.getInt("losses"),
+                            rs.getInt("streak"),
+                            rs.getInt("best_streak")
+                    ));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    /**
+     * Fetch combined player info and duels statistics for the specified player.
+     *
+     * @param name     the player name to query
+     * @param kitLimit maximum number of per-kit records
+     * @return an Optional containing {@link PlayerStats} if the player exists
+     */
+    public Optional<PlayerStats> getPlayerStatsByName(String name, int kitLimit) {
+        Optional<PlayerInfo> infoOpt = getPlayerInfoByName(name);
+        if (infoOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        PlayerInfo info = infoOpt.get();
+        DuelsAggregated agg = getDuelsAggregatedByName(name)
+                .orElse(new DuelsAggregated(0, 0, 0, 0, 0));
+        List<DuelsKitStats> rawKits = getDuelsPerKitByName(name, kitLimit);
+
+        List<PlayerStats.DuelsKit> kits = new ArrayList<>();
+        for (DuelsKitStats k : rawKits) {
+            kits.add(new PlayerStats.DuelsKit(k.kit, k.kills, k.deaths, k.wins, k.losses, k.streak, k.bestStreak));
+        }
+
+        PlayerStats stats = new PlayerStats(
+                info.uuid,
+                info.name,
+                info.rank,
+                info.firstJoin,
+                info.playtime,
+                agg.totalKills,
+                agg.totalDeaths,
+                agg.totalWins,
+                agg.totalLosses,
+                agg.bestStreak,
+                kits
+        );
+        return Optional.of(stats);
+    }
+
+    public Optional<PlayerStats> getPlayerStatsByUUID(java.util.UUID uuid, int kitLimit) {
+        Optional<PlayerInfo> infoOpt = getPlayerInfoByUUID(uuid);
+        if (infoOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        PlayerInfo info = infoOpt.get();
+        DuelsAggregated agg = getDuelsAggregatedByUUID(uuid)
+                .orElse(new DuelsAggregated(0, 0, 0, 0, 0));
+        List<DuelsKitStats> rawKits = getDuelsPerKitByUUID(uuid, kitLimit);
+
+        List<PlayerStats.DuelsKit> kits = new ArrayList<>();
+        for (DuelsKitStats k : rawKits) {
+            kits.add(new PlayerStats.DuelsKit(k.kit, k.kills, k.deaths, k.wins, k.losses, k.streak, k.bestStreak));
+        }
+
+        PlayerStats stats = new PlayerStats(
+                info.uuid,
+                info.name,
+                info.rank,
+                info.firstJoin,
+                info.playtime,
+                agg.totalKills,
+                agg.totalDeaths,
+                agg.totalWins,
+                agg.totalLosses,
+                agg.bestStreak,
+                kits
+        );
+        return Optional.of(stats);
+    }
+
+    // Simple container classes for internal mapping
+    public static class PlayerInfo {
+        public final String uuid;
+        public final String name;
+        public final String rank;
+        public final long firstJoin;
+        public final int playtime;
+
+        public PlayerInfo(String uuid, String name, String rank, long firstJoin, int playtime) {
+            this.uuid = uuid;
+            this.name = name;
+            this.rank = rank;
+            this.firstJoin = firstJoin;
+            this.playtime = playtime;
+        }
+    }
+
+    public static class DuelsAggregated {
+        public final int totalKills;
+        public final int totalDeaths;
+        public final int totalWins;
+        public final int totalLosses;
+        public final int bestStreak;
+
+        public DuelsAggregated(int totalKills, int totalDeaths, int totalWins, int totalLosses, int bestStreak) {
+            this.totalKills = totalKills;
+            this.totalDeaths = totalDeaths;
+            this.totalWins = totalWins;
+            this.totalLosses = totalLosses;
+            this.bestStreak = bestStreak;
+        }
+    }
+
+    public static class DuelsKitStats {
+        public final String kit;
+        public final int kills;
+        public final int deaths;
+        public final int wins;
+        public final int losses;
+        public final int streak;
+        public final int bestStreak;
+
+        public DuelsKitStats(String kit, int kills, int deaths, int wins, int losses, int streak, int bestStreak) {
+            this.kit = kit;
+            this.kills = kills;
+            this.deaths = deaths;
+            this.wins = wins;
+            this.losses = losses;
+            this.streak = streak;
+            this.bestStreak = bestStreak;
+        }
     }
 
     // expose DataSource if needed

--- a/src/main/java/etc/soap/paperDiscord/DiscordCommandListener.java
+++ b/src/main/java/etc/soap/paperDiscord/DiscordCommandListener.java
@@ -4,37 +4,36 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
-import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
-import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
-import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
-import net.dv8tion.jda.api.interactions.modals.Modal;
-import net.dv8tion.jda.api.interactions.components.text.TextInput;
-import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import net.dv8tion.jda.api.interactions.modals.Modal;
-import net.dv8tion.jda.api.interactions.modals.ModalMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.text.TextInput;
+import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.interactions.modals.ModalMapping;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.OfflinePlayer;
 
 import java.awt.*;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.UUID;
 
 public class DiscordCommandListener extends ListenerAdapter {
     private JDA jda; // JDA instance for the bot
@@ -82,8 +81,10 @@ public class DiscordCommandListener extends ListenerAdapter {
                                 .addOption(OptionType.USER, "user", "The Discord user whose perk should be reset."),
                         Commands.slash("serverstatus", "Check the status of a Minecraft server")
                                 .addOption(OptionType.STRING, "server_ip", "The IP of the server you want to check", false),
+                        Commands.slash("stats", "Show a player's statistics")
+                                .addOption(OptionType.STRING, "player", "The Minecraft player to look up", true),
                         Commands.slash("banformat", "Start the ban appeal process")
-                                .addOption(OptionType.USER, "user", "The Discord user to invite to fill out the ban appeal form"),
+                                .addOption(OptionType.USER, "user", "The Discord user to invite to fill out the ban appeal form", true),
                         Commands.slash("serverstatusembed", "Send a server status embed that updates every 30 seconds")
                 ).queue();
             } else {
@@ -121,6 +122,9 @@ public class DiscordCommandListener extends ListenerAdapter {
                 break;
             case "banformat":
                 handleBanFormatCommand(event);
+                break;
+            case "stats":
+                handleStatsCommand(event);
                 break;
             default:
                 event.reply("Unknown command").setEphemeral(true).queue();
@@ -585,60 +589,72 @@ public class DiscordCommandListener extends ListenerAdapter {
         String player = event.getOption("player").getAsString().trim();
         event.deferReply(false).queue();
 
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                Optional<PlayerStats> opt = db.getPlayerStatsByName(player, 6);
-                if (opt.isEmpty()) {
-                    event.getHook().sendMessage("No player found with name `" + player + "`.").queue();
-                    return;
-                }
-
-                PlayerStats p = opt.get();
-
-                long firstJoin = p.firstJoin;
-                if (firstJoin > 0 && firstJoin < 1_000_000_000_000L) firstJoin *= 1000L;
-                Instant joinInstant = Instant.ofEpochMilli(firstJoin);
-                String joinFormatted = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-                        .withZone(ZoneId.systemDefault())
-                        .format(joinInstant);
-
-                long seconds = p.playtime;
-                long days = TimeUnit.SECONDS.toDays(seconds);
-                long hours = TimeUnit.SECONDS.toHours(seconds) - TimeUnit.DAYS.toHours(days);
-                long minutes = TimeUnit.SECONDS.toMinutes(seconds) - TimeUnit.HOURS.toMinutes(TimeUnit.SECONDS.toHours(seconds));
-                String playtimeStr = (days > 0 ? (days + "d ") : "") + hours + "h " + minutes + "m";
-
-                double kdr = p.totalDeaths == 0 ? p.totalKills : ((double) p.totalKills / (double) p.totalDeaths);
-                String kdrStr = String.format("%.2f", kdr);
-
-                EmbedBuilder embed = new EmbedBuilder()
-                        .setTitle("Stats — " + p.name)
-                        .setColor(Color.CYAN)
-                        .addField("UUID", p.uuid, true)
-                        .addField("Rank", p.rank == null ? "None" : p.rank, true)
-                        .addField("Joined", joinFormatted, false)
-                        .addField("Playtime", playtimeStr, true)
-                        .addField("Duels — K/D/W/L", p.totalKills + "/" + p.totalDeaths + "/" + p.totalWins + "/" + p.totalLosses, true)
-                        .addField("K/D Ratio", kdrStr, true)
-                        .addField("Best Streak", String.valueOf(p.bestStreak), true)
-                        .setFooter("Requested by " + event.getUser().getName(), event.getUser().getAvatarUrl())
-                        .setTimestamp(Instant.now());
-
-                if (!p.kits.isEmpty()) {
-                    StringBuilder sb = new StringBuilder();
-                    for (PlayerStats.DuelsKit k : p.kits) {
-                        sb.append("**").append(k.kit).append("**: ")
-                                .append(k.kills).append("k / ").append(k.deaths).append("d / ")
-                                .append(k.wins).append("w\n");
-                    }
-                    embed.addField("Top kits", sb.toString(), false);
-                }
-
-                event.getHook().sendMessageEmbeds(embed.build()).queue();
-            } catch (Exception ex) {
-                ex.printStackTrace();
-                event.getHook().sendMessage("An error occurred while fetching stats for `" + player + "`.").queue();
+        // Resolve UUID on the main server thread to match in-game data
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            OfflinePlayer offline = Bukkit.getOfflinePlayer(player);
+            if (offline == null || (!offline.hasPlayedBefore() && !offline.isOnline())) {
+                event.getHook().sendMessage("No player found with name `" + player + "`.").queue();
+                return;
             }
+            UUID uuid = offline.getUniqueId();
+
+            // Query the database asynchronously using the resolved UUID
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                try {
+                    Optional<PlayerStats> opt = db.getPlayerStatsByUUID(uuid, 6);
+                    if (opt.isEmpty()) {
+                        event.getHook().sendMessage("No player found with name `" + player + "`.").queue();
+                        return;
+                    }
+
+                    PlayerStats p = opt.get();
+
+                    long firstJoin = p.firstJoin;
+                    if (firstJoin > 0 && firstJoin < 1_000_000_000_000L) firstJoin *= 1000L;
+                    Instant joinInstant = Instant.ofEpochMilli(firstJoin);
+                    String joinFormatted = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                            .withZone(ZoneId.systemDefault())
+                            .format(joinInstant);
+
+                    long seconds = p.playtime;
+                    long days = TimeUnit.SECONDS.toDays(seconds);
+                    long hours = TimeUnit.SECONDS.toHours(seconds) - TimeUnit.DAYS.toHours(days);
+                    long minutes = TimeUnit.SECONDS.toMinutes(seconds)
+                            - TimeUnit.HOURS.toMinutes(TimeUnit.SECONDS.toHours(seconds));
+                    String playtimeStr = (days > 0 ? (days + "d ") : "") + hours + "h " + minutes + "m";
+
+                    double kdr = p.totalDeaths == 0 ? p.totalKills : ((double) p.totalKills / (double) p.totalDeaths);
+                    String kdrStr = String.format("%.2f", kdr);
+
+                    EmbedBuilder embed = new EmbedBuilder()
+                            .setTitle("Stats — " + p.name)
+                            .setColor(Color.CYAN)
+                            .addField("UUID", p.uuid, true)
+                            .addField("Rank", p.rank == null ? "None" : p.rank, true)
+                            .addField("Joined", joinFormatted, false)
+                            .addField("Playtime", playtimeStr, true)
+                            .addField("Duels — K/D/W/L", p.totalKills + "/" + p.totalDeaths + "/" + p.totalWins + "/" + p.totalLosses, true)
+                            .addField("K/D Ratio", kdrStr, true)
+                            .addField("Best Streak", String.valueOf(p.bestStreak), true)
+                            .setFooter("Requested by " + event.getUser().getName(), event.getUser().getAvatarUrl())
+                            .setTimestamp(Instant.now());
+
+                    if (!p.kits.isEmpty()) {
+                        StringBuilder sb = new StringBuilder();
+                        for (PlayerStats.DuelsKit k : p.kits) {
+                            sb.append("**").append(k.kit).append("**: ")
+                                    .append(k.kills).append("k / ").append(k.deaths).append("d / ")
+                                    .append(k.wins).append("w\n");
+                        }
+                        embed.addField("Top kits", sb.toString(), false);
+                    }
+
+                    event.getHook().sendMessageEmbeds(embed.build()).queue();
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                    event.getHook().sendMessage("An error occurred while fetching stats for `" + player + "`.").queue();
+                }
+            });
         });
     }
 }

--- a/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
+++ b/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
@@ -18,32 +18,29 @@ public class PaperDiscord extends JavaPlugin {
     // We'll store references to our auto-posted messages so we can delete them on shutdown
     private Message embedMessage;
     private Message lastUpdatedMessage;
+    private DatabaseManager dbManager;
 
     @Override
     public void onEnable() {
+        // Ensure config exists before reading values
+        saveDefaultConfig();
 
         dbManager = new DatabaseManager(this);
-        discordCommandListener = new DiscordCommandListener(this, db);
+        discordCommandListener = new DiscordCommandListener(this, dbManager);
         discordCommandListener.startBot();
+        jda = discordCommandListener.getJDA();
 
-        saveDefaultConfig();
-        discordCommandListener = new DiscordCommandListener(this);
-        discordCommandListener.startBot();
-
-        // Delay to allow JDA to initialize before starting updaters
+        // Delay starting of status updaters slightly to ensure bot is ready
         Bukkit.getScheduler().runTaskLater(this, () -> {
             if (jda == null) {
-                jda = discordCommandListener.getJDA();
-            }
-            if (jda != null) {
-                cleanUpOldCommands();
-                startStatusUpdater();
-                // Auto-start the server status embed if enabled in config
-                if (getConfig().getBoolean("server-status.auto-embed", false)) {
-                    startAutoServerStatusEmbedUpdater();
-                }
-            } else {
                 getLogger().severe("Failed to initialize JDA. Status updater will not start.");
+                return;
+            }
+            cleanUpOldCommands();
+            startStatusUpdater();
+            // Auto-start the server status embed if enabled in config
+            if (getConfig().getBoolean("server-status.auto-embed", false)) {
+                startAutoServerStatusEmbedUpdater();
             }
         }, 60L);
     }
@@ -57,7 +54,16 @@ public class PaperDiscord extends JavaPlugin {
         Guild guild = jda.getGuildById(guildId);
         if (guild != null) {
             guild.retrieveCommands().queue(existingCommands -> {
-                List<String> commandsToKeep = List.of("boostperks", "reload", "balancedperks", "steadyperks", "resetperk", "serverstatus", "serverstatusembed", "banformat");
+                List<String> commandsToKeep = List.of(
+                        "boostperks",
+                        "reload",
+                        "balancedperks",
+                        "steadyperks",
+                        "resetperk",
+                        "serverstatus",
+                        "stats",
+                        "serverstatusembed",
+                        "banformat");
                 for (net.dv8tion.jda.api.interactions.commands.Command command : existingCommands) {
                     if (!commandsToKeep.contains(command.getName())) {
                         guild.deleteCommandById(command.getId()).queue();
@@ -83,6 +89,11 @@ public class PaperDiscord extends JavaPlugin {
         }
         if (jda != null) {
             jda.shutdown();
+            try {
+                jda.awaitShutdown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- resolve slash-command player names to server UUIDs before querying the database
- add UUID-based lookups for player info, aggregated stats, and per-kit breakdowns
- fix `/banformat` registration and command cleanup list

## Testing
- `mvn -q test` *(Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b557f026cc832f8cb667170560bd8f