### PR TITLE
Show only duel stats in /stats command

### DIFF
--- a/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
+++ b/src/main/java/etc/soap/paperDiscord/PaperDiscord.java
@@ -18,32 +18,29 @@ public class PaperDiscord extends JavaPlugin {
     // We'll store references to our auto-posted messages so we can delete them on shutdown
     private Message embedMessage;
     private Message lastUpdatedMessage;
+    private DatabaseManager dbManager;
 
     @Override
     public void onEnable() {
+        // Ensure config exists before reading values
+        saveDefaultConfig();
 
         dbManager = new DatabaseManager(this);
-        discordCommandListener = new DiscordCommandListener(this, db);
+        discordCommandListener = new DiscordCommandListener(this, dbManager);
         discordCommandListener.startBot();
+        jda = discordCommandListener.getJDA();
 
-        saveDefaultConfig();
-        discordCommandListener = new DiscordCommandListener(this);
-        discordCommandListener.startBot();
-
-        // Delay to allow JDA to initialize before starting updaters
+        // Delay starting of status updaters slightly to ensure bot is ready
         Bukkit.getScheduler().runTaskLater(this, () -> {
             if (jda == null) {
-                jda = discordCommandListener.getJDA();
-            }
-            if (jda != null) {
-                cleanUpOldCommands();
-                startStatusUpdater();
-                // Auto-start the server status embed if enabled in config
-                if (getConfig().getBoolean("server-status.auto-embed", false)) {
-                    startAutoServerStatusEmbedUpdater();
-                }
-            } else {
                 getLogger().severe("Failed to initialize JDA. Status updater will not start.");
+                return;
+            }
+            cleanUpOldCommands();
+            startStatusUpdater();
+            // Auto-start the server status embed if enabled in config
+            if (getConfig().getBoolean("server-status.auto-embed", false)) {
+                startAutoServerStatusEmbedUpdater();
             }
         }, 60L);
     }
@@ -57,7 +54,16 @@ public class PaperDiscord extends JavaPlugin {
         Guild guild = jda.getGuildById(guildId);
         if (guild != null) {
             guild.retrieveCommands().queue(existingCommands -> {
-                List<String> commandsToKeep = List.of("boostperks", "reload", "balancedperks", "steadyperks", "resetperk", "serverstatus", "serverstatusembed", "banformat");
+                List<String> commandsToKeep = List.of(
+                        "boostperks",
+                        "reload",
+                        "balancedperks",
+                        "steadyperks",
+                        "resetperk",
+                        "serverstatus",
+                        "stats",
+                        "serverstatusembed",
+                        "banformat");
                 for (net.dv8tion.jda.api.interactions.commands.Command command : existingCommands) {
                     if (!commandsToKeep.contains(command.getName())) {
                         guild.deleteCommandById(command.getId()).queue();
@@ -83,6 +89,11 @@ public class PaperDiscord extends JavaPlugin {
         }
         if (jda != null) {
             jda.shutdown();
+            try {
+                jda.awaitShutdown();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/src/main/java/etc/soap/paperDiscord/PlayerStats.java
+++ b/src/main/java/etc/soap/paperDiscord/PlayerStats.java
@@ -1,66 +1,31 @@
 package etc.soap.paperDiscord;
 
-import java.util.List;
-import java.util.Collections;
-
 /**
- * Single container class for player / duels data.
- * - Contains basic player info (uuid, name, rank, firstJoin, playtime)
- * - Contains aggregated duels totals
- * - Contains a list of per-kit DuelsKit objects
+ * Simple container for duel statistics.
+ * Holds the player's UUID/name along with their overall duel totals.
  */
 public class PlayerStats {
-    // Basic player info (player table)
     public final String uuid;
     public final String name;
-    public final String rank;
-    public final long firstJoin; // as stored in DB (could be seconds or millis)
-    public final int playtime;   // stored in DB (assumed seconds)
 
-    // Aggregated duels totals (from duels_kit_stats)
-    public final int totalKills;
-    public final int totalDeaths;
-    public final int totalWins;
-    public final int totalLosses;
+    public final int kills;
+    public final int deaths;
+    public final int wins;
+    public final int losses;
+    public final int streak;
     public final int bestStreak;
 
-    // Per-kit breakdown
-    public final List<DuelsKit> kits;
-
-    public PlayerStats(String uuid, String name, String rank, long firstJoin, int playtime,
-                       int totalKills, int totalDeaths, int totalWins, int totalLosses, int bestStreak,
-                       List<DuelsKit> kits) {
+    public PlayerStats(String uuid, String name,
+                       int kills, int deaths, int wins, int losses,
+                       int streak, int bestStreak) {
         this.uuid = uuid;
         this.name = name;
-        this.rank = rank;
-        this.firstJoin = firstJoin;
-        this.playtime = playtime;
-        this.totalKills = totalKills;
-        this.totalDeaths = totalDeaths;
-        this.totalWins = totalWins;
-        this.totalLosses = totalLosses;
+        this.kills = kills;
+        this.deaths = deaths;
+        this.wins = wins;
+        this.losses = losses;
+        this.streak = streak;
         this.bestStreak = bestStreak;
-        this.kits = kits == null ? Collections.emptyList() : List.copyOf(kits);
-    }
-
-    // Small inner class representing per-kit stats
-    public static class DuelsKit {
-        public final String kit;
-        public final int kills;
-        public final int deaths;
-        public final int wins;
-        public final int losses;
-        public final int streak;
-        public final int bestStreak;
-
-        public DuelsKit(String kit, int kills, int deaths, int wins, int losses, int streak, int bestStreak) {
-            this.kit = kit;
-            this.kills = kills;
-            this.deaths = deaths;
-            this.wins = wins;
-            this.losses = losses;
-            this.streak = streak;
-            this.bestStreak = bestStreak;
-        }
     }
 }
+


### PR DESCRIPTION
## Summary
- simplify stats lookup to query the `duels` table by UUID
- drop rank, join date, and playtime from stats output
- show kills/deaths/wins/losses and streaks in the `/stats` embed

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b557f026cc832f8cb667170560bd8f